### PR TITLE
Added "includeCollections" and "excludeCollections" feature to mongodump

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ or
 | `encryptSuffix`   |        | false    | `.enc`        | encrypt file suffix                                |
 | `includeCollections`   |        | false    | (none)        | Collections to include, if not specified all collections are included |
 | `excludeCollections`   |        | false    | (none)        | Collections to exclude, if not specified all collections are included |
+
 Simple example:
 ```
 const { MongoTools, MTOptions } = require("node-mongotools")

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ or
 | `encrypt`  |               | false    | false         | encrypt the dump using secret                      |
 | `secret`   | MT_SECRET     | false    | null          | secret to use if encrypt is enabled                |
 | `encryptSuffix`   |        | false    | `.enc`        | encrypt file suffix                                |
-
-
+| `includeCollections`   |        | false    | (none)        | Collections to include, if not specified all collections are included |
+| `excludeCollections`   |        | false    | (none)        | Collections to exclude, if not specified all collections are included |
 Simple example:
 ```
 const { MongoTools, MTOptions } = require("node-mongotools")

--- a/lib/MTOptions.js
+++ b/lib/MTOptions.js
@@ -19,6 +19,10 @@ class MTOptions {
     this.fileName = "fileName" in opt ? opt.fileName : null;                                            // target dump filename
     this.encrypt  = "encrypt"  in opt ? opt.encrypt  : false;
     this.secret   = "secret"   in opt ? opt.secret   : (process.env.MT_SECRET         || null);         // secret to encrypt dump
+
+    this.includeCollections = "includeCollections" in opt ? opt.includeCollections:null;
+    this.excludeCollections = "excludeCollections" in opt ? opt.excludeCollections:null;
+
     this.defaultEncryptSuffix = '.enc';
     this.encryptSuffix = "encryptSuffix" in opt ? opt.encryptSuffix : this.defaultEncryptSuffix;
 

--- a/lib/MTWrapper.js
+++ b/lib/MTWrapper.js
@@ -51,6 +51,23 @@ class MTWrapper {
      if ('ssl' in options && options.ssl) {
         command += ' --ssl';
      }
+
+     if('includeCollections' in options && Array.isArray(options.includeCollections)  &&  'excludeCollections' in options && Array.isArray(options.excludeCollections)  ){
+       return reject({ error: 'INVALID_OPTIONS', message: 'excludeCollections is not allowed when includeCollections is specified.'});
+     }
+
+     if('includeCollections' in options && Array.isArray(options.includeCollections)){
+       for(const collection of options.includeCollections){
+         command += ' --collection ' + collection;
+       }
+     }
+
+     if('excludeCollections' in options && Array.isArray(options.excludeCollections)){
+        for(const collection of options.excludeCollections){
+          command += ' --excludeCollection ' + collection;
+        }
+     }
+
      if (database === null || database === undefined || database === '') {
        return reject({ error: 'INVALID_OPTIONS', message: 'database name for dump is required.' });
      }


### PR DESCRIPTION
Added "includeCollections" and "excludeCollections" options to mongodump method to enable the --collection and --excludeCollection feature provided by mongodump

https://www.mongodb.com/docs/database-tools/mongodump/#std-option-mongodump.--collection
https://www.mongodb.com/docs/database-tools/mongodump/#std-option-mongodump.--excludeCollection

Tested for:
* Mongo v4.4.13
* Mongodump v100.5.2