### PR TITLE
Fix issue #44 add ssl options - manage boolean options using "1" value as true

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,35 +132,48 @@ These options are used by dump and restore.
 
 Either `uri` or `host`/`port`/`db`:
 
-| option   |  env         | required | default value | description                                        |
-|----------|--------------|----------|---------------|----------------------------------------------------|
-| `uri`    | MT_MONGO_URI | **true** | (none)        | mongodump uri, example `mongodb+srv://granted-user:MySecretHere@cluster0.xzryx.mongodb.net/tMyDatababse`   |
+| option | env          | required | default value | description                                                                                              |
+|--------|--------------|----------|---------------|----------------------------------------------------------------------------------------------------------|
+| `uri`  | MT_MONGO_URI | **true** | (none)        | mongodump uri, example `mongodb+srv://granted-user:MySecretHere@cluster0.xzryx.mongodb.net/tMyDatababse` |
 
 or
 
-| option    |  env          |  required | default value | description                                        |
-|-----------|---------------|----------|---------------|----------------------------------------------------|
-| `db`      | MT_MONGO_DB   | **true** | (none)        | mongo database name. For dump only, you could set it to '*' to dump all  |
-| `host`    | MT_MONGO_HOST | false    | `127.0.0.1`   | mongo database hostname                            |
-| `port`    | MT_MONGO_PORT | false    | `27017`       | mongo database port                                |
-| `username`| MT_MONGO_USER | false    | (none)        | mongo database username                            |
-| `password`| MT_MONGO_PWD  | false    | (none)        | mongo database password                            |
-| `authDb`  | MT_MONGO_AUTH_DB | false | `admin`       | mongo auth database                                |
+| option     | env              | required | default value | description                                                             |
+|------------|------------------|----------|---------------|-------------------------------------------------------------------------|
+| `db`       | MT_MONGO_DB      | **true** | (none)        | mongo database name. For dump only, you could set it to '*' to dump all |
+| `host`     | MT_MONGO_HOST    | false    | `127.0.0.1`   | mongo database hostname                                                 |
+| `port`     | MT_MONGO_PORT    | false    | `27017`       | mongo database port                                                     |
+| `username` | MT_MONGO_USER    | false    | (none)        | mongo database username                                                 |
+| `password` | MT_MONGO_PWD     | false    | (none)        | mongo database password                                                 |
+| `authDb`   | MT_MONGO_AUTH_DB | false    | `admin`       | mongo auth database                                                     |
+
+#### ssl options
+
+Optional ssl related options
+
+| option               | env                           | required | default value  | description                                                       |
+|----------------------|-------------------------------|----------|----------------|-------------------------------------------------------------------|
+| `ssl`                | MT_MONGO_SSL                  |  false   | (none)         | if "1" then add `--ssl` option                                    |
+| `sslCAFile`          | MT_MONGO_SSL_CA_FILE          |  false   | (none)         | .pem file containing the root certificate chain                   |
+| `sslPEMKeyFile`      | MT_MONGO_SSL_PEM_KEY_FILE     |  false   | (none)         | .pem file containing the certificate and key                      |
+| `sslPEMKeyPassword`  | MT_MONGO_SSL_PEM_KEY_PASSWORD |  false   | (none)         | password to decrypt the sslPEMKeyFile, if necessary               |
+| `sslCRLFile`         | MT_MONGO_SSL_CRL_FILE         |  false   | (none)         | pem file containing the certificate revocation list               |
+| `sslFIPSMode`        | MT_MONGO_SSL_FIPS            |  false   | (none)         | if "1" then use FIPS mode of the installed openssl library        |
+| `tlsInsecure`        | MT_MONGO_TLS_INSECURE        |  false   | (none)         | if "1" then  bypass the validation for server's certificate chain |
 
 ### mongodump options
 
-| option               |  env          | required | default value | description                                                           |
-|----------------------|---------------|----------|---------------|-----------------------------------------------------------------------|
-| `path`               | MT_PATH       | false    | `backup`      | dump target directory, created if it doesn't exist                    |
-| `dumpCmd `           |               | false    | `mongodump`   | mongodump binary                                                      |
-| `fileName`           |               | false    | `<dbName_date_time.gz>`  | dump target filename                                                  |
-| `ssl`                |               | false    | false         | add `--ssl` option                                                    |
-| `encrypt`            |               | false    | false         | encrypt the dump using secret                                         |
-| `secret`             | MT_SECRET     | false    | null          | secret to use if encrypt is enabled                                   |
-| `encryptSuffix`      |        | false    | `.enc`        | encrypt file suffix                                                   |
-| `includeCollections` |        | false    | (none)        | **Deprecated** - please use `collection`                              |
-| `collection`         |        | false    | (none)        | Collection to include, if not specified all collections are included  |
-| `excludeCollections` |        | false    | (none)        | Collections to exclude, if not specified all collections are included |
+| option               | env       | required | default value           | description                                                           |
+|----------------------|-----------|----------|-------------------------|-----------------------------------------------------------------------|
+| `path`               | MT_PATH   | false    | `backup`                | dump target directory, created if it doesn't exist                    |
+| `dumpCmd `           |           | false    | `mongodump`             | mongodump binary                                                      |
+| `fileName`           |           | false    | `<dbName_date_time.gz>` | dump target filename                                                  |
+| `encrypt`            |           | false    | false                   | encrypt the dump using secret                                         |
+| `secret`             | MT_SECRET | false    | null                    | secret to use if encrypt is enabled                                   |
+| `encryptSuffix`      |           | false    | `.enc`                  | encrypt file suffix                                                   |
+| `includeCollections` |           | false    | (none)                  | **Deprecated** - please use `collection`                              |
+| `collection`         |           | false    | (none)                  | Collection to include, if not specified all collections are included  |
+| `excludeCollections` |           | false    | (none)                  | Collections to exclude, if not specified all collections are included |
 
 Simple example:
 ```
@@ -178,15 +191,14 @@ mongoTools.mongodump({
 
 ### mongorestore options
 
-| option       |  env          |  required | default value   | description                                        |
-|--------------|---------------|-----------|-----------------|----------------------------------------------------|
-| `dumpFile`   | MT_DUMP_FILE  | true      | (none)          | dump file to restore                               |
-| `restoreCmd` |               | false     | `mongorestore`  | mongorestore binary                                |
-| `ssl`        |               | false     | false           | add `--ssl` option                                 |
-| `dropBeforeRestore` |        | false     | false           | set it to `true` to append `--drop` option         |
-| `deleteDumpAfterRestore` |   | false     | false           |  set it to `true` to remove restored backup file   |
-| `decrypt`    |               | false     | false           | decrypt the dump using secret. Activated if suffix is detected |
-| `secret`     | MT_SECRET     | false     | null            | secret to use if decrypt is enabled                |
+| option                   | env          | required | default value  | description                                                    |
+|--------------------------|--------------|----------|----------------|----------------------------------------------------------------|
+| `dumpFile`               | MT_DUMP_FILE | true     | (none)         | dump file to restore                                           |
+| `restoreCmd`             |              | false    | `mongorestore` | mongorestore binary                                            |
+| `dropBeforeRestore`      |              | false    | false          | set it to `true` to append `--drop` option                     |
+| `deleteDumpAfterRestore` |              | false    | false          | set it to `true` to remove restored backup file                |
+| `decrypt`                |              | false    | false          | decrypt the dump using secret. Activated if suffix is detected |
+| `secret`                 | MT_SECRET    | false    | null           | secret to use if decrypt is enabled                            |
 
 Simple example:
 ```
@@ -231,12 +243,12 @@ Backup out of safe time windows are called `deprecated backup`.
 - `rotationMinCount`: minimum deprecated backups to keep,
 - `rotationCleanCount`: number of (oldest) deprecated backups to delete.
 
-| option               |  env                     |  required | default value   | description                                       |
-|----------------------|--------------------------|-----------|-----------------|---------------------------------------------------|
-| `rotationDryMode`    | MT_ROTATION_DRY_MODE     | false     | false           | dont do delete actions, just print it             |
-| `rotationWindowsDays`| MT_ROTATION_WINDOWS_DAYS | true      | 15              | safe time windows in days since now               |
-| `rotationMinCount`   | MT_ROTATION_MIN_COUNT    | true      | 2               | minimum deprecated backups to keep.               |
-| `rotationCleanCount` | MT_ROTATION_CLEAN_COUNT  | true      | 10              | number of (oldest first) deprecated backups to delete. |
+| option                | env                      | required | default value | description                                            |
+|-----------------------|--------------------------|----------|---------------|--------------------------------------------------------|
+| `rotationDryMode`     | MT_ROTATION_DRY_MODE     | false    | false         | dont do delete actions, just print it                  |
+| `rotationWindowsDays` | MT_ROTATION_WINDOWS_DAYS | true     | 15            | safe time windows in days since now                    |
+| `rotationMinCount`    | MT_ROTATION_MIN_COUNT    | true     | 2             | minimum deprecated backups to keep.                    |
+| `rotationCleanCount`  | MT_ROTATION_CLEAN_COUNT  | true     | 10            | number of (oldest first) deprecated backups to delete. |
 
 Simple example:
 ```
@@ -263,8 +275,8 @@ npm run test
 
 ### Services or activated bots
 
-| badge  | name   | description  |
-|--------|-------|:--------|
-| ![CI/CD](https://github.com/boly38/node-mongotools/workflows/mongotools-ci/badge.svg) |Github actions|Continuous tests.
-| [![Audit](https://github.com/boly38/node-mongotools/actions/workflows/audit.yml/badge.svg)](https://github.com/boly38/node-mongotools/actions/workflows/audit.yml) |Github actions|Continuous vulnerability audit.
-| [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)|[Houndci](https://houndci.com/)|JavaScript  automated review (configured by `.hound.yml`)|
+| badge                                                                                                                                                              | name                            | description                                               |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|:----------------------------------------------------------|
+| ![CI/CD](https://github.com/boly38/node-mongotools/workflows/mongotools-ci/badge.svg)                                                                              | Github actions                  | Continuous tests.                                         |
+| [![Audit](https://github.com/boly38/node-mongotools/actions/workflows/audit.yml/badge.svg)](https://github.com/boly38/node-mongotools/actions/workflows/audit.yml) | Github actions                  | Continuous vulnerability audit.                           |
+| [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)                                                             | [Houndci](https://houndci.com/) | JavaScript  automated review (configured by `.hound.yml`) |

--- a/lib/MTOptions.js
+++ b/lib/MTOptions.js
@@ -1,14 +1,24 @@
 class MTOptions {
   constructor(options) {
+    const LO = '127.0.0.1';
     const opt = options ? options : {};
-    //~ database
-    this.uri      = "uri"      in opt ? opt.uri      : (process.env.MT_MONGO_URI      || null);         // database uri
-    this.db       = "db"       in opt ? opt.db       : (process.env.MT_MONGO_DB       || null);         // database name
-    this.host     = "host"     in opt ? opt.host     : (process.env.MT_MONGO_HOST     || '127.0.0.1');  // database hostname
-    this.port     = "port"     in opt ? opt.port     : (process.env.MT_MONGO_PORT     || 27017);        // database port
-    this.username = "username" in opt ? opt.username : (process.env.MT_MONGO_USER     || null);         // database username
-    this.password = "password" in opt ? opt.password : (process.env.MT_MONGO_PWD      || null);         // database password
-    this.authDb   = "authDb"   in opt ? opt.authDb   : (process.env.MT_MONGO_AUTH_DB  || 'admin');      // authenticate database
+    //~ database connect options
+    this.uri           = "uri"           in opt ? opt.uri           : (process.env.MT_MONGO_URI          || null);    // database uri
+    this.db            = "db"            in opt ? opt.db            : (process.env.MT_MONGO_DB           || null);    // database name
+    this.host          = "host"          in opt ? opt.host          : (process.env.MT_MONGO_HOST         || LO);      // database hostname
+    this.port          = "port"          in opt ? opt.port          : (process.env.MT_MONGO_PORT         || 27017);   // database port
+    this.username      = "username"      in opt ? opt.username      : (process.env.MT_MONGO_USER         || null);    // database username
+    this.password      = "password"      in opt ? opt.password      : (process.env.MT_MONGO_PWD          || null);    // database password
+    this.authDb        = "authDb"        in opt ? opt.authDb        : (process.env.MT_MONGO_AUTH_DB      || 'admin'); // authenticate database
+    //~ ssl options
+    this.ssl           = "ssl"           in opt ? opt.ssl           : (process.env.MT_MONGO_SSL          || null);    // if "1" then ssl is enabled
+    this.sslCAFile     = "sslCAFile"     in opt ? opt.sslCAFile     : (process.env.MT_MONGO_SSL_CA_FILE  || null);    // .pem file containing the root certificate chain
+    this.sslPEMKeyFile = "sslPEMKeyFile" in opt ? opt.sslPEMKeyFile : (process.env.MT_MONGO_SSL_PEM_KEY_FILE || null); // .pem file containing the certificate and key
+    this.sslPEMKeyPassword = "sslPEMKeyPassword" in opt ? opt.sslPEMKeyPassword : (process.env.MT_MONGO_SSL_PEM_KEY_PASSWORD || null);    // password to decrypt the sslPEMKeyFile, if necessary
+    this.sslCRLFile    = "sslCRLFile"    in opt ? opt.sslCRLFile    : (process.env.MT_MONGO_SSL_CRL_FILE || null);    // .pem file containing the certificate revocation list
+    this.sslFIPSMode   = "sslFIPSMode"   in opt ? opt.sslFIPSMode   : (process.env.MT_MONGO_SSL_FIPS     || null);    // if "1" then use FIPS mode of the installed openssl library
+    this.tlsInsecure   = "tlsInsecure"   in opt ? opt.tlsInsecure   : (process.env.MT_MONGO_TLS_INSECURE || null);    // if "1" then  bypass the validation for server's certificate chain and host name
+
     this.assumeValidPort();
 
     this.showCommand = "showCommand" in opt ? opt.showCommand : (process.env.MT_SHOW_COMMAND === 'true'); // show wrapped commands

--- a/lib/MTWrapper.js
+++ b/lib/MTWrapper.js
@@ -5,32 +5,27 @@ const dateFormat = require('dateformat');
 
 class MTWrapper {
 
-  mongodump(options) {
-   const mt = this;
-   return new Promise(async function(resolve, reject) {
-     if (!('db' in options) && !('uri' in options)) {
-       return reject({ error: 'INVALID_OPTIONS', message: 'db: database name for dump is required.' });
-     }
-     const dumpCmd = getOptionOrDefault(options, 'dumpCmd', 'mongodump');
-     const path = getOptionOrDefault(options, 'path', 'backup');
-     // create path if not exist
-     if (!fs.existsSync(path)) {
-       await fsPromise.mkdir(path, { recursive: true })
-         .catch((err) => {
-           return reject({ error: 'INVALID_OPTIONS', message: 'path: cannot create ' + path + ' :' + err });
-         });
-     }
-
-     var database = 'backup';
-     var command = "";
-     var uri = getOptionOrDefault(options, 'uri', null);
-
-     if (uri != null) {
+  databaseFromOptions(options, defaultDatabase = 'backup') {
+    var database = defaultDatabase;
+    const uri = getOptionOrDefault(options, 'uri', null);
+    if (uri != null) {
        if (!uri.includes('/')) {
          return reject({ error: 'INVALID_OPTIONS', message: 'uri: database name for dump is required.' });
        }
        database = uri.includes('?') ? uri.substring(uri.lastIndexOf('/') + 1, uri.indexOf('?')) :
                                       uri.substring(uri.lastIndexOf('/') + 1, uri.length);
+    } else if ('db' in options && options.db != '*') {
+       database = options.db;
+    }
+    if (database === null || database === undefined || database === '') {
+      return reject({ error: 'INVALID_OPTIONS', message: 'database name for dump is required.' });
+    }
+    return database;
+  }
+
+  commandConnectFromOptions(options, command = '', isRestore = false) {
+     const uri = getOptionOrDefault(options, 'uri', null);
+     if (uri != null) {
        command += ' --uri ' + uri
      } else {
        command += ' --host ' + getOptionOrDefault(options, 'host', '127.0.0.1') +
@@ -42,15 +37,37 @@ class MTWrapper {
            command += ' --authenticationDatabase ' + options.authDb;
          }
        }
-       if ('db' in options && options.db != '*') {
-         command += ' --db ' + options.db;
-         database = options.db;
+       if ('db' in options && options.db != '*' && (!isRestore || isLegacyRestoreDb())) {// keep legacy capability
+         command += ' --db ' + options.db;// deprecated for mongorestore: will produce additional deprecated stderr
+       } else if (isRestore && !isLegacyRestoreDb() && 'db' in options && options.db != '*') {
+         command += ' --nsInclude ' + options.db;
        }
      }
-     if ('ssl' in options && options.ssl) {
+     if (isBooleanOptionSet(options, 'ssl')) {
         command += ' --ssl';
      }
+     if (isOptionSet(options, 'sslCAFile')) {
+        command += ' --sslCAFile ' + options.sslCAFile;
+     }
+     if (isOptionSet(options, 'sslPEMKeyFile')) {
+        command += ' --sslPEMKeyFile ' + options.sslPEMKeyFile;
+     }
+     if (isOptionSet(options, 'sslPEMKeyPassword')) {
+        command += ' --sslPEMKeyPassword ' + options.sslPEMKeyPassword;
+     }
+     if (isOptionSet(options, 'sslCRLFile')) {
+        command += ' --sslCRLFile ' + options.sslCRLFile;
+     }
+     if (isBooleanOptionSet(options, 'sslFIPSMode')) {
+        command += ' --sslFIPSMode';
+     }
+     if (isBooleanOptionSet(options, 'tlsInsecure')) {
+        command += ' --tlsInsecure';
+     }
+     return command;
+  }
 
+  commandCollectionsFromOptions(options, command) {
      // deprecated includeCollections
      if (isOptionSet(options, 'collection') && isOptionSet(options, 'includeCollections')) {
        return reject({ error: 'INVALID_OPTIONS', message: 'please remove deprecated "includeCollections" option and use "collection" only.'});
@@ -81,10 +98,29 @@ class MTWrapper {
           command += ' --excludeCollection ' + collection;
         }
      }
+     return command;
+  }
 
-     if (database === null || database === undefined || database === '') {
-       return reject({ error: 'INVALID_OPTIONS', message: 'database name for dump is required.' });
+  mongodump(options) {
+   const mt = this;
+   return new Promise(async function(resolve, reject) {
+     if (!('db' in options) && !('uri' in options)) {
+       return reject({ error: 'INVALID_OPTIONS', message: 'db: database name for dump is required.' });
      }
+     const dumpCmd = getOptionOrDefault(options, 'dumpCmd', 'mongodump');
+     const path = getOptionOrDefault(options, 'path', 'backup');
+     // create path if not exist
+     if (!fs.existsSync(path)) {
+       await fsPromise.mkdir(path, { recursive: true })
+         .catch((err) => {
+           return reject({ error: 'INVALID_OPTIONS', message: 'path: cannot create ' + path + ' :' + err });
+         });
+     }
+
+     const database = mt.databaseFromOptions(options);
+     var command = mt.commandConnectFromOptions(options);
+     command = mt.commandCollectionsFromOptions(options, command);
+
      const dateTimeSuffix = getNowFormatted();
      const simplifiedName = database.replace(/[^a-zA-Z0-9\\-]/g,'_');
      const fileName = getOptionOrDefault(options, 'fileName', `${simplifiedName}__${dateTimeSuffix}.gz`);
@@ -119,6 +155,7 @@ class MTWrapper {
   }
 
   mongorestore(options, toRestore = null) {
+    const mt = this;
     return new Promise((resolve, reject) => {
       var dumpFile = toRestore == null ? options.dumpFile : toRestore;
       if (dumpFile === null || dumpFile === undefined) {
@@ -126,25 +163,8 @@ class MTWrapper {
       }
 
       var restoreCmd = getOptionOrDefault(options, 'restoreCmd', 'mongorestore');
-      var command = "";
+      var command = mt.commandConnectFromOptions(options, "", true);
 
-      var uri  = getOptionOrDefault(options, 'uri', null);
-      if (uri != null) {
-        command += ' --uri ' + uri
-      } else {
-        var command = restoreCmd + ' --host ' + getOptionOrDefault(options, 'host', '127.0.0.1') +
-                                   ' --port ' + getOptionOrDefault(options, 'port', 27017);
-        if (isOptionSet(options, 'username') && isOptionSet(options, 'password')) {
-          command += ' --username ' + options.username +
-                     ' --password ' + options.password;
-          if ('authDb' in options && options.authDb !== null) {
-            command += ' --authenticationDatabase ' + options.authDb;
-          }
-        }
-      }
-      if ('ssl' in options && options.ssl) {
-         command += ' --ssl';
-      }
       if ('dropBeforeRestore' in options && options.dropBeforeRestore == true) {
         command += ' --drop';
       }
@@ -194,12 +214,20 @@ function isOptionSet(options, optionName) {
   return optionName in options && isSet(options[optionName]);
 }
 
+function isBooleanOptionSet(options, optionName) {
+  return optionName in options && "1" === options[optionName];
+}
+
 function isSingleValue(value) {
   return (Array.isArray(value) && value.length === 1) || (typeof value === 'string' || value instanceof String);
 }
 
 function getSingleValue(value) {
   return (Array.isArray(value) && value.length === 1) ? value[0] : value;
+}
+
+function isLegacyRestoreDb() {
+  return "1" === process.env.MT_MONGO_LEGACY_RESTORE_DB;
 }
 
 module.exports = MTWrapper;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "preinstall": "npx force-resolutions",
     "test": "echo test&& mocha --exit --unhandled-rejections=strict tests/*.test.js --timeout 50000",
+    "wip": "echo test&& mocha --exit --unhandled-rejections=strict tests/mongo-wrapper-unit.test.js",
     "ci-test": "echo ci-test&& nyc --reporter text --reporter cobertura --reporter html --reporter=lcov --lines 66 mocha --exit --unhandled-rejections=strict tests/*.test.js --timeout 50000"
   },
   "author": "Boly38 <boly38@gmail.com>",

--- a/tests/mongo-wrapper-unit.test.js
+++ b/tests/mongo-wrapper-unit.test.js
@@ -1,0 +1,87 @@
+const MTWrapper = require("../lib/MTWrapper");
+const MTOptions = require("../lib/MTOptions");
+
+const chai = require('chai');
+const assert = require('assert').strict;
+const expect = chai.expect
+chai.should();
+chai.use(require('chai-string'));
+
+const testDbUsername = process.env.MT_MONGO_USER || null;
+const testDbPassword = process.env.MT_MONGO_PWD || null;
+const testDbAuth = testDbUsername !== null && testDbPassword != null ? `${testDbUsername}:${testDbPassword}@` : '';
+const testDbAuthSuffix = testDbUsername !== null && testDbPassword != null ? '?authSource=admin' : '';
+const testFixedPort = 17017;
+const testDbToken = process.env.MT_DROPBOX_TOKEN || null;
+
+const testBackupDirectory = 'tests/backup';
+const testDbName = 'myDbForTest';
+const testDbUri = `mongodb://${testDbAuth}127.0.0.1:${testFixedPort}/${testDbName}${testDbAuthSuffix}`;
+
+var wrapper = new MTWrapper();
+
+describe("MTWrapper unit tests", function() {
+
+    it("should wrap dump commandConnectFromOptions db user basic", async function() {
+      const mtOptions = new MTOptions({
+        db: testDbName,
+        port: testFixedPort,
+        path: testBackupDirectory
+      });
+
+      var command = wrapper.commandConnectFromOptions(mtOptions, '--beginning');
+
+      command.should.be.eql("--beginning --host 127.0.0.1 --port 17017 --username root --password mypass --authenticationDatabase admin --db myDbForTest");
+    });
+
+    it("should wrap dump commandConnectFromOptions uri ssl", async function() {
+      const mtOptions = new MTOptions({
+        uri: testDbUri,
+        ssl: "1",
+        sslCAFile: "/tmp/myCAfile",
+        sslPEMKeyFile: "/tmp/pem/sslPEMKeyFile",
+        sslCRLFile: "/tmp/pem/sslCRLFile",
+        sslPEMKeyPassword: "strongPassHere",
+        sslFIPSMode: "1",
+        tlsInsecure: "1"
+      });
+
+      var command = wrapper.commandConnectFromOptions(mtOptions, '--beginning');
+
+      command.should.be.eql("--beginning --uri mongodb://root:mypass@127.0.0.1:17017/myDbForTest?authSource=admin "
+      +"--ssl --sslCAFile /tmp/myCAfile --sslPEMKeyFile /tmp/pem/sslPEMKeyFile --sslPEMKeyPassword strongPassHere "
+      +"--sslCRLFile /tmp/pem/sslCRLFile --sslFIPSMode --tlsInsecure");
+    });
+
+    it("should wrap restore commandConnectFromOptions db user basic", async function() {
+      const mtOptions = new MTOptions({
+        db: testDbName,
+        port: testFixedPort,
+        path: testBackupDirectory
+      });
+
+      var command = wrapper.commandConnectFromOptions(mtOptions, '--beginning', true);
+
+      command.should.be.eql("--beginning --host 127.0.0.1 --port 17017 --username root --password mypass --authenticationDatabase admin --nsInclude myDbForTest");
+    });
+
+    it("should wrap restore commandConnectFromOptions uri ssl", async function() {
+      const mtOptions = new MTOptions({
+        uri: testDbUri,
+        ssl: "1",
+        sslCAFile: "/tmp/myCAfile",
+        sslPEMKeyFile: "/tmp/pem/sslPEMKeyFile",
+        sslCRLFile: "/tmp/pem/sslCRLFile",
+        sslPEMKeyPassword: "strongPassHere",
+        sslFIPSMode: "1",
+        tlsInsecure: "1"
+      });
+
+      var command = wrapper.commandConnectFromOptions(mtOptions, '--beginning', true);
+
+      command.should.be.eql("--beginning --uri mongodb://root:mypass@127.0.0.1:17017/myDbForTest?authSource=admin "
+      +"--ssl --sslCAFile /tmp/myCAfile --sslPEMKeyFile /tmp/pem/sslPEMKeyFile --sslPEMKeyPassword strongPassHere "
+      +"--sslCRLFile /tmp/pem/sslCRLFile --sslFIPSMode --tlsInsecure");
+    });
+
+});


### PR DESCRIPTION
Fix #44 add ssl options

stay todo:
- [x] update main readme
- [x] true/false options (ex. `ssl`, `sslFIPSMode`, `tlsInsecure`) adopt "1" to match true. This is a breaking change for ssl, so increment major version