### PR TITLE
fix #60 qs vulnerable version and fix #62 ci mongo binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,10 +44,27 @@ jobs:
       # - run: npm ci # need package.json.lock
       run: npm install
 
+    - name: Setup mongosh # src: https://www.mongodb.com/docs/mongodb-shell/install/
+      run: |
+        echo "setup keys"
+        wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
+        sudo apt-get install gnupg
+        wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
+        echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+        echo "aptitude update"
+        sudo apt-get update
+        echo "aptitude install mongodb-mongosh"
+        sudo apt-get install -y mongodb-mongosh
+
+    - name: Setup mongoDB Tools # src: https://www.mongodb.com/docs/database-tools/installation/installation-linux/
+      run: |        
+        echo "aptitude install mongodb-database-tools"
+        sudo apt install mongodb-database-tools
+
     - name: Setup mongo user
       # doc: https://docs.mongodb.com/manual/reference/built-in-roles/ "Backup and Restoration Roles"
       # doc: https://docs.mongodb.com/manual/reference/method/db.createUser/
-      run: mongo admin --eval 'db.createUser({user:"root",pwd:"mypass",roles:[{"role":"readWrite","db":"myDbForTest"}, "restore"]});'
+      run: mongosh admin --eval 'db.createUser({user:"root",pwd:"mypass",roles:[{"role":"readWrite","db":"myDbForTest"}, "restore"]});'
 
     - name: Run tests
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,13 @@ jobs:
           package-lock.json
 
     - name: Install dependencies
-      # - run: npm ci # need package.json.lock
-      run: npm install
+      # npx force-resolutions : in case of Permission denied: run it locally to fix package-lock.json
+      run: |
+        echo "install"
+        npm run preinstall
+        npm install
+        echo "show outdated (if any)"
+        npm outdated --depth=3 || echo "you must think about update your dependencies :)"
 
     - name: Setup mongosh # src: https://www.mongodb.com/docs/mongodb-shell/install/
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 
 #IntelliJ
 *.iml
+.idea/
 
 #Project defaukt backup directory
 dropbox/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "dateformat": "^5.0.3",
-        "dropbox-v2-api": "^2.5.3"
+        "dropbox-v2-api": "^2.5.9"
       },
       "devDependencies": {
         "chai": "^4.3.6",
@@ -918,6 +918,11 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "node_modules/compress-json": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/compress-json/-/compress-json-2.1.2.tgz",
+      "integrity": "sha512-91247RD8bKQXzRmXUS4zGT250mhw86+J9X8w2L2SGtRE7g0CvzjOETFaFmsDdaXPWv8T7L9iiM7kdcnnH3BH7w=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1045,10 +1050,11 @@
       }
     },
     "node_modules/dropbox-v2-api": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/dropbox-v2-api/-/dropbox-v2-api-2.5.6.tgz",
-      "integrity": "sha512-5QJ4awTSKCwSTX7Lc6l1c3iDGdFlco08rItpYR2AT7jygTkWQ41wdK2yKCTyi5UgdiorkslPmstPpXbb8ncWYw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dropbox-v2-api/-/dropbox-v2-api-2.5.9.tgz",
+      "integrity": "sha512-3cjyMVONLDPcnJCB0PymlddDn8DP2JIrtIi8iPSumZrDr/QvJFwcklG+/yC9JZNmZ+/NszcALB2rZfJT88q/cQ==",
       "dependencies": {
+        "compress-json": "2.1.2",
         "request": "2.88.2"
       }
     },
@@ -2369,9 +2375,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "engines": {
         "node": ">=0.6"
       }
@@ -2430,7 +2436,7 @@
         "mime-types": "~2.1.19",
         "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
+        "qs": "^6.5.3",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
@@ -3644,6 +3650,11 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "compress-json": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/compress-json/-/compress-json-2.1.2.tgz",
+      "integrity": "sha512-91247RD8bKQXzRmXUS4zGT250mhw86+J9X8w2L2SGtRE7g0CvzjOETFaFmsDdaXPWv8T7L9iiM7kdcnnH3BH7w=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3741,10 +3752,11 @@
       "dev": true
     },
     "dropbox-v2-api": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/dropbox-v2-api/-/dropbox-v2-api-2.5.6.tgz",
-      "integrity": "sha512-5QJ4awTSKCwSTX7Lc6l1c3iDGdFlco08rItpYR2AT7jygTkWQ41wdK2yKCTyi5UgdiorkslPmstPpXbb8ncWYw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dropbox-v2-api/-/dropbox-v2-api-2.5.9.tgz",
+      "integrity": "sha512-3cjyMVONLDPcnJCB0PymlddDn8DP2JIrtIi8iPSumZrDr/QvJFwcklG+/yC9JZNmZ+/NszcALB2rZfJT88q/cQ==",
       "requires": {
+        "compress-json": "2.1.2",
         "request": "2.88.2"
       }
     },
@@ -3930,11 +3942,6 @@
         "minimatch": "^3.1.2",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "^3.1.2"
-        }
       }
     },
     "glob-parent": {
@@ -4384,8 +4391,12 @@
           }
         },
         "minimatch": {
-          "version": "^3.1.2",
-          "dev": true
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
         }
       }
     },
@@ -4732,9 +4743,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -4783,7 +4794,7 @@
         "mime-types": "~2.1.19",
         "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
+        "qs": "^6.5.3",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
@@ -4979,11 +4990,6 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.1.2"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "^3.1.2"
-        }
       }
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
   },
   "dependencies": {
     "dateformat": "^5.0.3",
-    "dropbox-v2-api": "^2.5.3"
+    "dropbox-v2-api": "^2.5.9"
   },
   "devDependencies": {
     "chai": "^4.3.6",
     "chai-string": "^1.5.0",
-    "mocha": "^10.1.0",
     "minimatch": "^3.1.2",
+    "mocha": "^10.1.0",
     "npm-force-resolutions": "^0.0.10",
     "nyc": "^15.1.0"
   },


### PR DESCRIPTION
- in order to keep ci-test, we need to keep ubuntu-18.04 version but this version is deprecated. cf #62 


---

fix #60 qs vulnerable version and fix #62 ci mongo binaries
